### PR TITLE
Add switches for replaying only some requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typescript/server-replay",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@typescript/server-replay",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "MIT",
       "dependencies": {
         "@typescript/server-harness": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/server-replay",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-server-replay#readme",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "license": "MIT",
   "description": "Replay server requests from a file",
   "keywords": [


### PR DESCRIPTION
`-s` keeps the initial `configure`, file open and close requests, the final non-exit request, and the exit request. 
`-S` keeps the initial `configure`, the final file open request, the final non-exit request, and the exit request.