### PR TITLE
Increased stack-size

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/server-replay",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-server-replay#readme",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "license": "MIT",
   "description": "Replay server requests from a file",
   "keywords": [

--- a/replay.js
+++ b/replay.js
@@ -234,6 +234,7 @@ async function main() {
     const nodeArgs = [
         "--max-old-space-size=4096",
         "--expose-gc",
+        "--stack-size=2048",
         // "--require=E:/tsserver-stress/node_modules/pprof-it/dist/index.js",
     ];
 


### PR DESCRIPTION
There have been some issues generated that failed due to the stack-size being too short and cannot be reproduced by Visual Studio Code editor. My suspect is that electron increases the size for 32 and 64bit to size to 4MB and 8MB respectively, avoiding the issue entirely. Reference [electron_main_win.cc#L97](https://github.com/electron/electron/blob/38512efd25a159ddc64a54c22ef9eb6dd60064ec/shell/app/electron_main_win.cc#L97) and [BUILD.gn#L1240](https://github.com/electron/electron/blob/38512efd25a159ddc64a54c22ef9eb6dd60064ec/BUILD.gn#L1240)

Examples of issues generated by the stack trace:
https://github.com/microsoft/TypeScript/issues/59678#issuecomment-2295421302
https://github.com/microsoft/TypeScript/issues/59752#issuecomment-2309022346

This change increases the stack-size to 2MB, which is the minimal amount for the tests to pass.