### PR TITLE
Move to TS; copy package installation here

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-*.js
-!replay.js
-*.map
-*.d.ts
+dist
 node_modules
 *.tsbuildinfo
 *.tgz

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch install",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/dist/cli.js",
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
+            "args": ["install", "../code/TypeScript"],
+            "preLaunchTask": "npm: build"
+        }
+    ]
+}

--- a/bin/tsreplay
+++ b/bin/tsreplay
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('../replay.js')

--- a/bin/tsreplay.js
+++ b/bin/tsreplay.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../dist/cli.js')

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,8 +1,0 @@
-{
-    "compilerOptions": {
-        "strict": true,
-    },
-    "files": [
-        "./replay.js"
-    ]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typescript/server-replay",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@typescript/server-replay",
-      "version": "0.2.13",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@typescript/server-harness": "^0.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@typescript/server-harness": "^0.3.4",
         "glob": "^10.5.0",
+        "js-yaml": "^4.1.1",
         "json5": "^2.2.3",
         "yargs": "^16.2.0"
       },
@@ -18,6 +19,7 @@
         "tsreplay": "bin/tsreplay.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.9.1",
         "@types/yargs": "^16.0.4",
         "typescript": "^6.0.3"
@@ -129,6 +131,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
@@ -180,6 +189,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -327,6 +342,28 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json5": {
@@ -664,6 +701,12 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true
     },
+    "@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true
+    },
     "@types/node": {
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
@@ -705,6 +748,11 @@
       "requires": {
         "color-convert": "^2.0.1"
       }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -811,6 +859,14 @@
       "requires": {
         "@isaacs/cliui": "^8.0.2",
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "requires": {
+        "argparse": "^2.0.1"
       }
     },
     "json5": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,143 @@
 {
   "name": "@typescript/server-replay",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@typescript/server-replay",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "@typescript/server-harness": "^0.3.4",
+        "glob": "^10.5.0",
+        "json5": "^2.2.3",
         "yargs": "^16.2.0"
       },
       "bin": {
-        "tsreplay": "bin/tsreplay"
+        "tsreplay": "bin/tsreplay.js"
       },
       "devDependencies": {
-        "@types/node": "^14.18.12",
+        "@types/node": "^25.9.1",
         "@types/yargs": "^16.0.4",
-        "typescript": "^4.8.3"
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/node": {
-      "version": "14.18.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.23.tgz",
-      "integrity": "sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==",
-      "dev": true
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -69,6 +181,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -95,6 +222,26 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -108,12 +255,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -124,6 +308,100 @@
         "node": ">=8"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -132,10 +410,58 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -156,23 +482,77 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -220,11 +600,78 @@
     }
   },
   "dependencies": {
+    "@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "requires": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
+        },
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+          "requires": {
+            "ansi-regex": "^6.2.2"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
+      }
+    },
+    "@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "optional": true
+    },
     "@types/node": {
-      "version": "14.18.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.23.tgz",
-      "integrity": "sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==",
-      "dev": true
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "requires": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -259,6 +706,19 @@
         "color-convert": "^2.0.1"
       }
     },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "requires": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -282,6 +742,21 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -292,23 +767,129 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
+    "foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "requires": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "requires": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "requires": {
+        "@isaacs/cliui": "^8.0.2",
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+    },
+    "lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "requires": {
+        "brace-expansion": "^2.0.2"
+      }
+    },
+    "minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
+    },
+    "package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "requires": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+    },
     "string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
@@ -325,14 +906,46 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true
+    },
+    "undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -54,15 +54,15 @@
   },
   "dependencies": {
     "@typescript/server-harness": "^0.3.4",
-    "yargs": "^16.2.0",
     "glob": "^10.5.0",
+    "js-yaml": "^4.1.1",
     "json5": "^2.2.3",
-    "js-yaml": "^4.1.1"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.9.1",
     "@types/yargs": "^16.0.4",
-    "typescript": "^6.0.3",
-    "@types/js-yaml": "^4.0.9"
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,20 +20,27 @@
     "type": "git",
     "url": "git+https://github.com/microsoft/typescript-server-replay.git"
   },
-  "main": "./replay.js",
+  "main": "./dist/replay.js",
+  "types": "./dist/replay.d.ts",
   "bin": {
-    "tsreplay": "./bin/tsreplay"
+    "tsreplay": "./bin/tsreplay.js"
   },
+  "files": [
+    "dist",
+    "bin"
+  ],
   "scripts": {
-    "build": "tsc -p jsconfig.json"
+    "build": "tsc"
   },
   "dependencies": {
     "@typescript/server-harness": "^0.3.4",
+    "glob": "^10.5.0",
+    "json5": "^2.2.3",
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@types/node": "^14.18.12",
+    "@types/node": "^25.9.1",
     "@types/yargs": "^16.0.4",
-    "typescript": "^4.8.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.map",
     "bin",
     "LICENSE",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/server-replay",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-server-replay#readme",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "Replay server requests from a file",
   "keywords": [
@@ -20,27 +20,48 @@
     "type": "git",
     "url": "git+https://github.com/microsoft/typescript-server-replay.git"
   },
-  "main": "./dist/replay.js",
-  "types": "./dist/replay.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./installPackages": {
+      "types": "./dist/installPackages.d.ts",
+      "default": "./dist/installPackages.js"
+    },
+    "./stradaReplay": {
+      "types": "./dist/stradaReplay.d.ts",
+      "default": "./dist/stradaReplay.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "tsreplay": "./bin/tsreplay.js"
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "LICENSE",
+    "README.md",
+    "SECURITY.md",
+    "SUPPORT.md"
   ],
   "scripts": {
     "build": "tsc"
   },
   "dependencies": {
     "@typescript/server-harness": "^0.3.4",
+    "yargs": "^16.2.0",
     "glob": "^10.5.0",
     "json5": "^2.2.3",
-    "yargs": "^16.2.0"
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",
     "@types/yargs": "^16.0.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "@types/js-yaml": "^4.0.9"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,79 @@
+import * as process from "process";
+import yargs from "yargs";
+import { runReplay } from "./stradaReplay.js";
+import { installDependencies } from "./installDeps.js";
+
+void yargs(process.argv.slice(2))
+    .command(
+        "strada-replay <project> <requests> <server>",
+        "Replay a TS <= 6 fuzzer repro",
+        yargs => yargs
+            .positional("project", { type: "string", desc: "location of directory containing repro project", demandOption: true })
+            .positional("requests", { type: "string", desc: "location of file containing server request stubs", demandOption: true })
+            .positional("server", { type: "string", desc: "location of tsserver.js", demandOption: true })
+            .options({
+                "t": {
+                    alias: ["traceDir", "trace-dir"],
+                    describe: "Enable tsserver tracing and write outputs to specified directory",
+                    type: "string",
+                },
+                "l": {
+                    alias: ["logDir", "log-dir"],
+                    describe: "Enable tsserver logging and write log to specified directory",
+                    type: "string",
+                },
+                "i": {
+                    alias: ["inspectPort", "inspect-port"],
+                    describe: "Enable --inspect-brk on the specified port",
+                    type: "number",
+                },
+                "u": {
+                    alias: ["unattended"],
+                    describe: "Stop at the first sign of trouble and use line-oriented output",
+                    type: "boolean",
+                },
+                "s": {
+                    alias: ["simple"],
+                    describe: "Replay only file opening and closing, plus the final request",
+                    type: "boolean",
+                },
+                "S": {
+                    alias: ["superSimple", "super-simple"],
+                    describe: "Replay only the final file opening and the final request",
+                    type: "boolean",
+                },
+            })
+            .conflicts("s", "S"),
+        async args => {
+            await runReplay({
+                project: args.project,
+                requests: args.requests,
+                server: args.server,
+                traceDir: args.t,
+                logDir: args.l,
+                inspectPort: args.i,
+                unattended: args.u,
+                simple: args.s,
+                superSimple: args.S,
+            });
+        },
+    )
+    .command(
+        "install <project>",
+        "Install dependencies for a repro project",
+        yargs => yargs
+            .options({
+                "p": {
+                    alias: ["project"],
+                    describe: "location of directory containing repro project",
+                    type: "string",
+                    demandOption: true,
+                },
+            }),
+        async args => {
+            await installDependencies(args.project);
+        },
+    )
+    .help("h").alias("h", "help")
+    .strict()
+    .parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import * as process from "process";
 import yargs from "yargs";
 import { runReplay } from "./stradaReplay.js";
-import { installDependencies } from "./installDeps.js";
+import { installDependencies } from "./installPackages.js";
 
 void yargs(process.argv.slice(2))
     .command(
@@ -62,16 +62,26 @@ void yargs(process.argv.slice(2))
         "install <project>",
         "Install dependencies for a repro project",
         yargs => yargs
+            .positional("project", { type: "string", desc: "location of directory containing repro project", demandOption: true })
             .options({
-                "p": {
-                    alias: ["project"],
-                    describe: "location of directory containing repro project",
-                    type: "string",
-                    demandOption: true,
+                "quietOutput": {
+                    describe: "Run install commands in quiet/silent mode",
+                    type: "boolean",
+                    default: false,
+                },
+                "recursiveSearch": {
+                    describe: "Recursively search directories for package.json files to install dependencies for",
+                    type: "boolean",
+                    default: true,
+                },
+                "timeout": {
+                    describe: "timeout for installing dependencies (ms)",
+                    type: "number",
+                    default: 10 * 60 * 1000,
                 },
             }),
         async args => {
-            await installDependencies(args.project);
+            await installDependencies(args.project, args.quietOutput, args.recursiveSearch, args.timeout);
         },
     )
     .help("h").alias("h", "help")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./installPackages.js";
+export * from "./stradaReplay.js";

--- a/src/installDeps.ts
+++ b/src/installDeps.ts
@@ -1,0 +1,316 @@
+import fs = require("fs");
+import globCps = require("glob");
+import json5 = require("json5");
+import path = require("path");
+
+export async function installDependencies(project: string): Promise<void> {
+    // TODO: Implement dependency installation for the repro project at `project`.
+    throw new Error(`'install' command is not yet implemented (project: ${project})`);
+}
+
+/**
+ * String value will be the unqualified command name.
+ */
+export enum InstallTool {
+    Npm = "npm",
+    Yarn = "yarn",
+    Pnpm = "pnpm",
+}
+
+export interface InstallCommand {
+    directory: string;
+    prettyDirectory: string;
+    tool: InstallTool;
+    arguments: readonly string[];
+}
+
+/**
+ * Traverses the given directory and returns a list of commands that can be used, in order, to install
+ * the packages required for building.
+ */
+export async function installPackages(repoDir: string, ignoreScripts: boolean, quietOutput: boolean, recursiveSearch: boolean, monorepoPackages?: readonly string[], types?: string[]): Promise<InstallCommand[]> {
+    monorepoPackages = monorepoPackages ?? await getMonorepoOrder(repoDir);
+
+    const repoName = path.basename(repoDir);
+
+    const isRepoYarn = await exists(path.join(repoDir, "yarn.lock"));
+    // The existence of .yarnrc.yml indicates that this repo uses yarn 2
+    const isRepoYarn2 = await exists(path.join(repoDir, ".yarnrc.yml"));
+    const isRepoPnpm = await exists(path.join(repoDir, "pnpm-lock.yaml"));
+
+    const commands: InstallCommand[] = [];
+
+    const globPattern = recursiveSearch ? "**/package.json" : "package.json";
+    const packageFiles = glob(repoDir, globPattern);
+
+    for (const packageFile of packageFiles) {
+        let inMonorepoPackageDir = false;
+        for (const monorepoPackage of monorepoPackages) {
+            if (inMonorepoPackageDir = packageFile.startsWith(monorepoPackage)) break;
+        }
+        if (inMonorepoPackageDir) {
+            // Skipping installation of monorepo package
+            continue;
+        }
+
+        // CONSIDER: If we're ignoring scripts, there are lerna packages, and we're not
+        // using yarn workspaces, we might want to `lerna bootstrap`.  In practice,
+        // this has not proven to be necessary, since this combination is uncommon.
+
+        const packageRoot = path.dirname(packageFile);
+
+        // Heuristic, these are rarely valuable and often fail.
+        if (/fixtures?/i.test(packageRoot)) {
+            continue;
+        }
+
+        let tool: InstallTool;
+        let args: string[];
+
+        const isProjectYarn2 = isRepoYarn2 || await exists(path.join(packageRoot, ".yarnrc.yml"));
+        if (isProjectYarn2 ||
+            await exists(path.join(packageRoot, "yarn.lock")) ||
+            (isRepoYarn && !(await exists(path.join(packageRoot, "package-lock.json"))))) {
+            tool = InstallTool.Yarn;
+
+            // Yarn 2 dropped support for most `install` arguments
+            if (isProjectYarn2) {
+                args = ["install", "--no-immutable"]
+
+                if (ignoreScripts) {
+                    // TODO: this seems to be called --skip-build in yarn 3 - we might want to try to distinguish
+                    args.push("--mode=skip-build");
+                }
+            }
+            else {
+                args = ["install", "--ignore-engines"];
+
+                if (ignoreScripts) {
+                    args.push("--ignore-scripts");
+                }
+
+                if (quietOutput) {
+                    args.push("--silent");
+                }
+            }
+        }
+        else if (isRepoPnpm || await exists(path.join(packageRoot, "pnpm-lock.yaml"))) {
+            tool = InstallTool.Pnpm;
+            args = ["install", "--no-frozen-lockfile", "--prefer-offline"];
+
+            if (ignoreScripts) {
+                args.push("--ignore-scripts");
+            }
+
+            if (quietOutput) {
+                args.push("--reporter=silent");
+            }
+
+        }
+        else if (await exists(path.join(packageRoot, "package.json"))) {
+            tool = InstallTool.Npm;
+
+            const haveLock = await exists(path.join(packageRoot, "package-lock.json")) ||
+                await hasCurrentShrinkwrap(packageRoot);
+
+            args = [haveLock ? "ci" : "install", "--prefer-offline", "--no-audit", "--no-progress", "--legacy-peer-deps"];
+
+            if (ignoreScripts) {
+                args.push("--ignore-scripts");
+            }
+
+            if (quietOutput) {
+                args.push("-q");
+            }
+        }
+        else {
+            continue;
+        }
+
+        const prettyDirectory = path.join(repoName, path.relative(repoDir, packageRoot));
+
+        commands.push({
+            directory: packageRoot,
+            prettyDirectory,
+            tool,
+            arguments: args,
+        });
+
+        if (types && types.length > 0) {
+            // `types` is only present for user tests and all known user tests use npm, not yarn
+            // Besides, we're using --no-save, so it shouldn't matter which tool we use
+            const typesPackageNames = types.map(t => `@types/${t}`);
+            const args = ["install", ...typesPackageNames, "--no-save", "--ignore-scripts", "--legacy-peer-deps"];
+
+            commands.push({
+                directory: packageRoot,
+                prettyDirectory,
+                tool: InstallTool.Npm,
+                arguments: args
+            });
+        }
+    }
+
+    return commands;
+}
+
+async function hasCurrentShrinkwrap(packageRoot: string): Promise<boolean> {
+    if (!exists(path.join(packageRoot, "npm-shrinkwrap.json"))) {
+        return false;
+    }
+    
+    try {
+        const contents = await fs.promises.readFile(path.join(packageRoot, "npm-shrinkwrap.json"), { encoding: "utf-8" });
+        const value = json5.parse(contents);
+        return +value.lockfileVersion >= 1;
+    }
+    catch {
+        return false;
+    }
+}
+
+/**
+ * Returns true if the path exists.
+ */
+export async function exists(path: string): Promise<boolean> {
+    return !!await fs.promises.stat(path, { throwIfNoEntry: false });
+}
+
+/**
+ * `glob`, but ignoring node_modules and symlinks, and returning absolute paths.
+ */
+export function glob(cwd: string, pattern: string): string[] {
+    return globCps.sync(pattern, { cwd, absolute: true, ignore: "**/node_modules/**", follow: false })
+}
+
+/**
+ * Heuristically returns a list of package.json paths in monorepo dependency order.
+ * NB: Does not actually consume lerna.json.
+ */
+export async function getMonorepoOrder(repoDir: string): Promise<readonly string[]> {
+    const yarnOrNpmLockFiles = glob(repoDir, "**/{yarn.lock,package-lock.json}");
+    if (yarnOrNpmLockFiles.length) {
+        const workspaceOrder: string[] = [];
+        for (const lockFile of yarnOrNpmLockFiles) {
+            const dir = path.dirname(lockFile);
+            const pkgPath = path.join(dir, "package.json");
+            if (await exists(pkgPath)) {
+                const contents = await fs.promises.readFile(pkgPath, { encoding: "utf-8" });
+                const pkg: Package = json5.parse(contents);
+                const workspaces = pkg.workspaces;
+                if (workspaces) {
+                    const workspaceDirs = "packages" in workspaces ? workspaces.packages : workspaces;
+                    for (const workspaceDir of workspaceDirs) {
+                        // workspaceDir might end with `/*` - glob will do the right thing
+                        const pkgPaths = glob(dir, path.join(workspaceDir, "package.json"));
+                        await appendOrderedMonorepoPackages(pkgPaths, workspaceOrder);
+                    }
+                }
+            }
+        }
+        if (workspaceOrder.length) {
+            return workspaceOrder;
+        }
+    }
+
+    const pnpmWorkspaceFiles = glob(repoDir, "**/pnpm-workspace.yaml");
+    if (pnpmWorkspaceFiles.length) {
+        const pnpmWorkspaceOrder: string[] = [];
+        for (const pnpmWorkspaceFile of pnpmWorkspaceFiles) {
+            const contents = await fs.promises.readFile(pnpmWorkspaceFile, { encoding: "utf-8" });
+            const config = yaml.load(contents) as { packages?: string[] } | undefined; // undefined for an empty test fixture
+            const workspaceDirs = config?.packages;
+            if (workspaceDirs) {
+                const pnpmDir = path.dirname(pnpmWorkspaceFile);
+                for (const workspaceDir of workspaceDirs) {
+                    // CONSIDER: Should technically exclude those beginning with `!`
+                    if (workspaceDir.startsWith("!")) continue;
+                        // workspaceDir might end with `/*` - glob will do the right thing
+                    const pkgPaths = glob(pnpmDir, path.join(workspaceDir, "package.json"));
+                    await appendOrderedMonorepoPackages(pkgPaths, pnpmWorkspaceOrder);
+                }
+            }
+        }
+        if (pnpmWorkspaceOrder.length) {
+            return pnpmWorkspaceOrder;
+        }
+    }
+
+    const lernaFiles = glob(repoDir, "**/lerna.json");
+    if (lernaFiles.length) {
+        const lernaOrder: string[] = [];
+        for (const lernaFile of lernaFiles) {
+            const lernaDir = path.dirname(lernaFile);
+            if (await exists(path.join(lernaDir, "packages"))) {
+                const pkgPaths = glob(path.join(lernaDir, "packages"), "**/package.json");
+                await appendOrderedMonorepoPackages(pkgPaths, lernaOrder);
+            }
+        }
+        if (lernaOrder.length) {
+            return lernaOrder;
+        }
+    }
+
+    return [];
+}
+
+interface Package {
+    meta_dir: string,
+    meta_state: "unvisited" | "visiting" | "visited",
+    name: string,
+    workspaces?: readonly string[] | { packages: readonly string[] },
+    dependencies?: readonly string[],
+    devDependencies?: readonly string[],
+    peerDependencies?: readonly string[],
+}
+
+async function appendOrderedMonorepoPackages(pkgPaths: string[], monorepoOrder: string[]) {
+    const pkgs = await Promise.all(pkgPaths.map(async (pkgPath) => {
+        const contents = await fs.promises.readFile(pkgPath, { encoding: "utf-8" });
+        const pkg: Package = json5.parse(contents);
+        pkg.meta_dir = path.dirname(pkgPath);
+        pkg.meta_state = "unvisited";
+        return pkg;
+    }));
+    const pkgMap: Record<string, Package | undefined> = {};
+    for (const pkg of pkgs) {
+        pkgMap[pkg.name] = pkg;
+    }
+
+    while (true) {
+        const pkg = pkgs.find(p => p.meta_state === "unvisited");
+        if (!pkg) break;
+        visit(pkg);
+    }
+
+    function visit(pkg: Package): void {
+        // "visiting" indicates a cycle, which some monorepo systems (e.g. lerna) allow
+        if (pkg.meta_state !== "unvisited") return;
+
+        pkg.meta_state = "visiting";
+
+        if (pkg.dependencies) {
+            for (const dep in pkg.dependencies) {
+                const depPkg = pkgMap[dep];
+                if (depPkg) visit(depPkg);
+            }
+        }
+
+        if (pkg.devDependencies) {
+            for (const dep in pkg.devDependencies) {
+                const depPkg = pkgMap[dep];
+                if (depPkg) visit(depPkg);
+            }
+        }
+
+        if (pkg.peerDependencies) {
+            for (const dep in pkg.peerDependencies) {
+                const depPkg = pkgMap[dep];
+                if (depPkg) visit(depPkg);
+            }
+        }
+
+        pkg.meta_state = "visited";
+        monorepoOrder.push(pkg.meta_dir);
+    }
+}

--- a/src/installPackages.ts
+++ b/src/installPackages.ts
@@ -142,7 +142,7 @@ export async function getInstallPackagesCommands(repoDir: string, quietOutput: b
 }
 
 async function hasCurrentShrinkwrap(packageRoot: string): Promise<boolean> {
-    if (!exists(path.join(packageRoot, "npm-shrinkwrap.json"))) {
+    if (!await exists(path.join(packageRoot, "npm-shrinkwrap.json"))) {
         return false;
     }
     
@@ -159,7 +159,7 @@ async function hasCurrentShrinkwrap(packageRoot: string): Promise<boolean> {
 async function installPackages(repoDir: string, commands: readonly InstallCommand[], timeoutMs: number) {
     let usedYarn = false;
 
-    const installEnv: Record<string, string> = {
+    const installEnv: NodeJS.ProcessEnv = {
         ...process.env,
         // yarn2 produces extremely verbose output unless CI=true is set and it should be harmless for yarn1 and npm
         CI: "true",
@@ -309,24 +309,29 @@ async function getMonorepoOrder(repoDir: string): Promise<readonly string[]> {
 }
 
 interface Package {
-    meta_dir: string,
-    meta_state: "unvisited" | "visiting" | "visited",
     name: string,
     workspaces?: readonly string[] | { packages: readonly string[] },
-    dependencies?: readonly string[],
-    devDependencies?: readonly string[],
-    peerDependencies?: readonly string[],
+    dependencies?: Record<string, string>,
+    devDependencies?: Record<string, string>,
+    peerDependencies?: Record<string, string>,
+}
+
+interface MonorepoPackage extends Package {
+    meta_dir: string,
+    meta_state: "unvisited" | "visiting" | "visited",
 }
 
 async function appendOrderedMonorepoPackages(pkgPaths: string[], monorepoOrder: string[]) {
-    const pkgs = await Promise.all(pkgPaths.map(async (pkgPath) => {
+    const pkgs = await Promise.all(pkgPaths.map(async (pkgPath): Promise<MonorepoPackage> => {
         const contents = await fs.promises.readFile(pkgPath, { encoding: "utf-8" });
         const pkg: Package = json5.parse(contents);
-        pkg.meta_dir = path.dirname(pkgPath);
-        pkg.meta_state = "unvisited";
-        return pkg;
+        return {
+            ...pkg,
+            meta_dir: path.dirname(pkgPath),
+            meta_state: "unvisited",
+        };
     }));
-    const pkgMap: Record<string, Package | undefined> = {};
+    const pkgMap: Record<string, MonorepoPackage | undefined> = {};
     for (const pkg of pkgs) {
         pkgMap[pkg.name] = pkg;
     }
@@ -337,7 +342,7 @@ async function appendOrderedMonorepoPackages(pkgPaths: string[], monorepoOrder: 
         visit(pkg);
     }
 
-    function visit(pkg: Package): void {
+    function visit(pkg: MonorepoPackage): void {
         // "visiting" indicates a cycle, which some monorepo systems (e.g. lerna) allow
         if (pkg.meta_state !== "unvisited") return;
 
@@ -377,7 +382,7 @@ interface SpawnResult {
 }
 
 /** Returns undefined if and only if executions times out. */
-function spawnWithTimeoutAsync(cwd: string, command: string, args: readonly string[], timeoutMs: number, env?: {}): Promise<SpawnResult | undefined> {
+function spawnWithTimeoutAsync(cwd: string, command: string, args: readonly string[], timeoutMs: number, env?: NodeJS.ProcessEnv): Promise<SpawnResult | undefined> {
     console.log(`${cwd}> ${command} ${args.join(" ")}`);
     return new Promise<SpawnResult | undefined>((resolve, reject) => {
         if (timeoutMs <= 0) {
@@ -394,16 +399,32 @@ function spawnWithTimeoutAsync(cwd: string, command: string, args: readonly stri
         });
 
         let timedOut = false;
+        let settled = false;
 
         let stdout = "";
         let stderr = "";
 
+        // If the process fails to spawn (e.g. command not found), `close` never fires, so handle
+        // `error` explicitly to ensure the promise always settles.
+        childProcess.once("error", err => {
+            if (!timedOut && !settled) {
+                settled = true;
+                clearTimeout(timeout);
+                reject(err);
+            }
+        });
+
         childProcess.once("close", (code, signal) => {
-            if (!timedOut) {
+            if (!timedOut && !settled) {
+                settled = true;
                 clearTimeout(timeout);
                 resolve({ stdout, stderr, code, signal });
             }
         });
+
+        // Decode chunks as strings so `cappedAppend` never has to deal with Buffers.
+        childProcess.stdout.setEncoding("utf-8");
+        childProcess.stderr.setEncoding("utf-8");
 
         childProcess.stdout.on("data", data => {
             stdout = cappedAppend(stdout, data);
@@ -414,7 +435,11 @@ function spawnWithTimeoutAsync(cwd: string, command: string, args: readonly stri
         });
 
         const timeout = setTimeout(async () => {
+            if (settled) {
+                return;
+            }
             timedOut = true;
+            settled = true;
             await killTree(childProcess);
             resolve(undefined);
         }, timeoutMs | 0); // Truncate to int
@@ -422,7 +447,19 @@ function spawnWithTimeoutAsync(cwd: string, command: string, args: readonly stri
 }
 
 function killTree(childProcess: cp.ChildProcessWithoutNullStreams): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
+    return new Promise<void>((resolve) => {
+        // Best-effort kill of just the root process. Used as a fallback when we can't enumerate
+        // descendants, and as the final step once we have.
+        const killRoot = () => {
+            try {
+                childProcess.kill();
+            }
+            catch {
+                // The process may have already exited; nothing more we can do.
+                resolve();
+            }
+        };
+
         // Ideally, we would wait for all of the processes to close, but we only get events for
         // this one, so we'll kill it last and hope for the best.
         childProcess.once("close", () => {
@@ -431,7 +468,8 @@ function killTree(childProcess: cp.ChildProcessWithoutNullStreams): Promise<void
 
         cp.exec("ps -e -o pid,ppid --no-headers", (err, stdout) => {
             if (err) {
-                reject (err);
+                // `ps` may fail. Fall back to a best-effort kill of just the root process.
+                killRoot();
                 return;
             }
 
@@ -471,8 +509,15 @@ function killTree(childProcess: cp.ChildProcessWithoutNullStreams): Promise<void
 
             console.log(`Killing process ${childProcessPid} and its descendents: ${strictDescendentPids.join(", ")}`);
 
-            strictDescendentPids.forEach(pid => process.kill(pid));
-            childProcess.kill();
+            for (const pid of strictDescendentPids) {
+                try {
+                    process.kill(pid);
+                }
+                catch {
+                    // Best effort - the process may have already exited or be inaccessible.
+                }
+            }
+            killRoot();
             // Resolve when we detect that childProcess has closed (above)
         });
     });

--- a/src/installPackages.ts
+++ b/src/installPackages.ts
@@ -226,14 +226,14 @@ ${spawnResult.stdout.trim() || "No stdout"}\n${spawnResult.stderr.trim() || "No 
 /**
  * Returns true if the path exists.
  */
-export async function exists(path: string): Promise<boolean> {
+async function exists(path: string): Promise<boolean> {
     return new Promise(resolve => fs.exists(path, e => resolve(e)));
 }
 
 /**
  * `glob`, but ignoring node_modules and symlinks, and returning absolute paths.
  */
-export function glob(cwd: string, pattern: string): string[] {
+function glob(cwd: string, pattern: string): string[] {
     return globCps.sync(pattern, { cwd, absolute: true, ignore: "**/node_modules/**", follow: false })
 }
 
@@ -241,7 +241,7 @@ export function glob(cwd: string, pattern: string): string[] {
  * Heuristically returns a list of package.json paths in monorepo dependency order.
  * NB: Does not actually consume lerna.json.
  */
-export async function getMonorepoOrder(repoDir: string): Promise<readonly string[]> {
+async function getMonorepoOrder(repoDir: string): Promise<readonly string[]> {
     const yarnOrNpmLockFiles = glob(repoDir, "**/{yarn.lock,package-lock.json}");
     if (yarnOrNpmLockFiles.length) {
         const workspaceOrder: string[] = [];
@@ -369,7 +369,7 @@ async function appendOrderedMonorepoPackages(pkgPaths: string[], monorepoOrder: 
     }
 }
 
-export interface SpawnResult {
+interface SpawnResult {
     stdout: string,
     stderr: string,
     code: number | null,
@@ -377,7 +377,7 @@ export interface SpawnResult {
 }
 
 /** Returns undefined if and only if executions times out. */
-export function spawnWithTimeoutAsync(cwd: string, command: string, args: readonly string[], timeoutMs: number, env?: {}): Promise<SpawnResult | undefined> {
+function spawnWithTimeoutAsync(cwd: string, command: string, args: readonly string[], timeoutMs: number, env?: {}): Promise<SpawnResult | undefined> {
     console.log(`${cwd}> ${command} ${args.join(" ")}`);
     return new Promise<SpawnResult | undefined>((resolve, reject) => {
         if (timeoutMs <= 0) {
@@ -495,7 +495,7 @@ function cappedAppend(current: string, data: string): string {
     return hasTruncationMessage ? tail : TRUNCATION_MESSAGE + tail;
 }
 
-export async function execAsync(cwd: string, command: string): Promise<string> {
+async function execAsync(cwd: string, command: string): Promise<string> {
     return new Promise((resolve, reject) => {
         console.log(`${cwd}> ${command}`);
         cp.exec(command, { cwd }, (err, stdout, stderr) => {

--- a/src/installPackages.ts
+++ b/src/installPackages.ts
@@ -1,11 +1,14 @@
+import { constants } from "buffer";
+import cp = require("child_process");
 import fs = require("fs");
 import globCps = require("glob");
 import json5 = require("json5");
 import path = require("path");
+import yaml = require("js-yaml");
 
-export async function installDependencies(project: string): Promise<void> {
-    // TODO: Implement dependency installation for the repro project at `project`.
-    throw new Error(`'install' command is not yet implemented (project: ${project})`);
+export async function installDependencies(project: string, quietOutput: boolean, recursiveSearch: boolean, packageTimeout: number): Promise<void> {
+    const commands = await getInstallPackagesCommands(project, quietOutput, recursiveSearch);
+    await installPackages(project, commands, packageTimeout);
 }
 
 /**
@@ -28,7 +31,7 @@ export interface InstallCommand {
  * Traverses the given directory and returns a list of commands that can be used, in order, to install
  * the packages required for building.
  */
-export async function installPackages(repoDir: string, ignoreScripts: boolean, quietOutput: boolean, recursiveSearch: boolean, monorepoPackages?: readonly string[], types?: string[]): Promise<InstallCommand[]> {
+export async function getInstallPackagesCommands(repoDir: string, quietOutput: boolean, recursiveSearch: boolean, monorepoPackages?: readonly string[], types?: string[]): Promise<InstallCommand[]> {
     monorepoPackages = monorepoPackages ?? await getMonorepoOrder(repoDir);
 
     const repoName = path.basename(repoDir);
@@ -75,19 +78,11 @@ export async function installPackages(repoDir: string, ignoreScripts: boolean, q
 
             // Yarn 2 dropped support for most `install` arguments
             if (isProjectYarn2) {
-                args = ["install", "--no-immutable"]
-
-                if (ignoreScripts) {
-                    // TODO: this seems to be called --skip-build in yarn 3 - we might want to try to distinguish
-                    args.push("--mode=skip-build");
-                }
+                // TODO: this seems to be called --skip-build in yarn 3 - we might want to try to distinguish
+                args = ["install", "--no-immutable", "--mode=skip-build"];
             }
             else {
-                args = ["install", "--ignore-engines"];
-
-                if (ignoreScripts) {
-                    args.push("--ignore-scripts");
-                }
+                args = ["install", "--ignore-engines", "--ignore-scripts"];
 
                 if (quietOutput) {
                     args.push("--silent");
@@ -96,11 +91,7 @@ export async function installPackages(repoDir: string, ignoreScripts: boolean, q
         }
         else if (isRepoPnpm || await exists(path.join(packageRoot, "pnpm-lock.yaml"))) {
             tool = InstallTool.Pnpm;
-            args = ["install", "--no-frozen-lockfile", "--prefer-offline"];
-
-            if (ignoreScripts) {
-                args.push("--ignore-scripts");
-            }
+            args = ["install", "--no-frozen-lockfile", "--prefer-offline", "--ignore-scripts"];
 
             if (quietOutput) {
                 args.push("--reporter=silent");
@@ -113,11 +104,7 @@ export async function installPackages(repoDir: string, ignoreScripts: boolean, q
             const haveLock = await exists(path.join(packageRoot, "package-lock.json")) ||
                 await hasCurrentShrinkwrap(packageRoot);
 
-            args = [haveLock ? "ci" : "install", "--prefer-offline", "--no-audit", "--no-progress", "--legacy-peer-deps"];
-
-            if (ignoreScripts) {
-                args.push("--ignore-scripts");
-            }
+            args = [haveLock ? "ci" : "install", "--prefer-offline", "--no-audit", "--no-progress", "--legacy-peer-deps", "--ignore-scripts"];
 
             if (quietOutput) {
                 args.push("-q");
@@ -169,11 +156,78 @@ async function hasCurrentShrinkwrap(packageRoot: string): Promise<boolean> {
     }
 }
 
+async function installPackages(repoDir: string, commands: readonly InstallCommand[], timeoutMs: number) {
+    let usedYarn = false;
+
+    const installEnv: Record<string, string> = {
+        ...process.env,
+        // yarn2 produces extremely verbose output unless CI=true is set and it should be harmless for yarn1 and npm
+        CI: "true",
+        YARN_ENABLE_SCRIPTS: "false",
+        npm_config_ignore_scripts: "true",
+        npm_config_allow_git: "none",
+        // pnpm reads npm_config_* too, but not in 11+
+        pnpm_config_ignore_scripts: "true",
+        // Block git-protocol dependencies entirely.
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "protocol.allow",
+        GIT_CONFIG_VALUE_0: "never",
+    };
+
+    try {
+        let timedOut = false;
+        const startMs = performance.now();
+        for (const { directory: packageRoot, tool, arguments: args } of commands) {
+            if (timedOut) break;
+
+            usedYarn = usedYarn || tool === InstallTool.Yarn;
+
+            const elapsedMs = performance.now() - startMs;
+            const packageRootDescription = packageRoot.substring(repoDir.length + 1) || "root directory";
+
+            const spawnResult = await spawnWithTimeoutAsync(packageRoot, tool, args, timeoutMs - elapsedMs, installEnv);
+            if (!spawnResult) {
+                throw new Error(`Timed out after ${timeoutMs} ms`);
+            }
+
+            if (spawnResult.code || spawnResult.signal) {
+                if (tool === InstallTool.Npm && args[0] === "ci" && /update your lock file/.test(spawnResult.stderr)) {
+                    const elapsedMs2 = performance.now() - startMs;
+                    const args2 = args.slice();
+                    args2[0] = "install";
+                    const spawnResult2 = await spawnWithTimeoutAsync(packageRoot, tool, args2, timeoutMs - elapsedMs2, installEnv);
+                    if (spawnResult2 && !spawnResult2.code && !spawnResult2.signal) {
+                        continue; // Succeeded on retry
+                    }
+                }
+
+                const errorText = `Exited with ${spawnResult.code ? `code ${spawnResult.code}` : `signal ${spawnResult.signal}`}
+${spawnResult.stdout.trim() || "No stdout"}\n${spawnResult.stderr.trim() || "No stderr"}`;
+
+                if (!/ENOSPC/.test(errorText) && (/(?:ex|s)amples?\//i.test(packageRootDescription) || /tests?\//i.test(packageRootDescription))) {
+                    console.log(`Ignoring package install error from non-product folder ${packageRootDescription}:`);
+                    console.log(insetLines(reduceSpew(errorText)));
+                }
+                else {
+                    throw new Error(`Failed to install packages for ${packageRootDescription}:\n${errorText}`);
+                }
+            }
+        }
+    }
+    finally {
+        if (usedYarn) {
+            await execAsync(repoDir, "yarn cache clean --all");
+        }
+    }
+}
+
+// === Shared helpers ===
+
 /**
  * Returns true if the path exists.
  */
 export async function exists(path: string): Promise<boolean> {
-    return !!await fs.promises.stat(path, { throwIfNoEntry: false });
+    return new Promise(resolve => fs.exists(path, e => resolve(e)));
 }
 
 /**
@@ -313,4 +367,159 @@ async function appendOrderedMonorepoPackages(pkgPaths: string[], monorepoOrder: 
         pkg.meta_state = "visited";
         monorepoOrder.push(pkg.meta_dir);
     }
+}
+
+export interface SpawnResult {
+    stdout: string,
+    stderr: string,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+}
+
+/** Returns undefined if and only if executions times out. */
+export function spawnWithTimeoutAsync(cwd: string, command: string, args: readonly string[], timeoutMs: number, env?: {}): Promise<SpawnResult | undefined> {
+    console.log(`${cwd}> ${command} ${args.join(" ")}`);
+    return new Promise<SpawnResult | undefined>((resolve, reject) => {
+        if (timeoutMs <= 0) {
+            resolve(undefined);
+            return;
+        }
+
+        // We use `spawn`, rather than `execFile`, because package installation tends to write a lot
+        // of data to stdout, overflowing `execFile`'s buffer.
+        const childProcess = cp.spawn(command, args, {
+            cwd,
+            env,
+            windowsHide: true,
+        });
+
+        let timedOut = false;
+
+        let stdout = "";
+        let stderr = "";
+
+        childProcess.once("close", (code, signal) => {
+            if (!timedOut) {
+                clearTimeout(timeout);
+                resolve({ stdout, stderr, code, signal });
+            }
+        });
+
+        childProcess.stdout.on("data", data => {
+            stdout = cappedAppend(stdout, data);
+        });
+
+        childProcess.stderr.on("data", data => {
+            stderr = cappedAppend(stderr, data);
+        });
+
+        const timeout = setTimeout(async () => {
+            timedOut = true;
+            await killTree(childProcess);
+            resolve(undefined);
+        }, timeoutMs | 0); // Truncate to int
+    });
+}
+
+function killTree(childProcess: cp.ChildProcessWithoutNullStreams): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        // Ideally, we would wait for all of the processes to close, but we only get events for
+        // this one, so we'll kill it last and hope for the best.
+        childProcess.once("close", () => {
+            resolve();
+        });
+
+        cp.exec("ps -e -o pid,ppid --no-headers", (err, stdout) => {
+            if (err) {
+                reject (err);
+                return;
+            }
+
+            const childProcessPid = childProcess.pid!;
+            let sawChildProcessPid = false;
+
+            const childMap: Record<number, number[]> = {};
+            const pidList = stdout.trim().split(/\s+/);
+            for (let i = 0; i + 1 < pidList.length; i += 2) {
+                const childPid = +pidList[i];
+                const parentPid = +pidList[i + 1];
+
+                childMap[parentPid] ||= [];
+                childMap[parentPid].push(childPid);
+
+                sawChildProcessPid ||= childPid === childProcessPid;
+            }
+
+            if (!sawChildProcessPid) {
+                // Descendent processes may still be alive, but we have no way to identify them
+                resolve();
+                return;
+            }
+
+            const strictDescendentPids: number[] = [];
+            const stack: number[] = [ childProcessPid ];
+            while (stack.length) {
+                const pid = stack.pop()!;
+                if (pid !== childProcessPid) {
+                    strictDescendentPids.push(pid);
+                }
+                const children = childMap[pid];
+                if (children) {
+                    stack.push(...children);
+                }
+            }
+
+            console.log(`Killing process ${childProcessPid} and its descendents: ${strictDescendentPids.join(", ")}`);
+
+            strictDescendentPids.forEach(pid => process.kill(pid));
+            childProcess.kill();
+            // Resolve when we detect that childProcess has closed (above)
+        });
+    });
+}
+
+const MAX_LENGTH = constants.MAX_STRING_LENGTH;
+const TRUNCATION_MESSAGE = "\n...truncated...\n";
+
+function cappedAppend(current: string, data: string): string {
+    if (current.length + data.length <= MAX_LENGTH) {
+        return current + data;
+    }
+    // Truncate before appending to avoid exceeding the limit.
+    // Preserve the tail of the output.
+    const hasTruncationMessage = current.startsWith(TRUNCATION_MESSAGE);
+    const available = hasTruncationMessage ? MAX_LENGTH : MAX_LENGTH - TRUNCATION_MESSAGE.length;
+    const tail = data.length >= available
+        ? data.slice(data.length - available)
+        : current.slice(current.length - (available - data.length)) + data;
+    return hasTruncationMessage ? tail : TRUNCATION_MESSAGE + tail;
+}
+
+export async function execAsync(cwd: string, command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        console.log(`${cwd}> ${command}`);
+        cp.exec(command, { cwd }, (err, stdout, stderr) => {
+            if (stdout?.length) {
+                console.log(stdout);
+            }
+            if (stderr?.length) {
+                console.log(stderr); // To stdout to maintain order
+            }
+
+            if (err) {
+                return reject(err);
+            }
+            return resolve(stdout);
+        });
+    });
+}
+
+function insetLines(text: string): string {
+    return text.trimEnd().replace(/(^|\n)/g, "$1> ");
+}
+
+function reduceSpew(message: string): string {
+    // These are uninteresting in general and actually problematic when there are
+    // thousands of instances of ENOSPC (which also appears as an error anyway)
+    return message.replace(/npm WARN.*\n/g, "");
 }

--- a/src/stradaReplay.ts
+++ b/src/stradaReplay.ts
@@ -1,98 +1,65 @@
-const sh = require("@typescript/server-harness");
-const fs = require("fs");
-const process = require("process");
-const path = require("path");
-const readline = require("readline");
-const events = require("events");
-const yargs = require("yargs");
+import * as sh from "@typescript/server-harness";
+import * as fs from "fs";
+import * as process from "process";
+import * as path from "path";
+import * as readline from "readline";
+import * as events from "events";
 
-const args = yargs(process.argv.slice(2))
-    .command("$0 <project> <requests> <server>", "Replay a fuzzer repro", yargs => yargs
-        .positional("project", { type: "string", desc: "location of directory containing repro project" })
-        .positional("requests", { type: "string", desc: "location of file containing server request stubs" })
-        .positional("server", { type: "string", desc: "location of tsserver.js" })
-        .options({
-            "t": {
-                alias: ["traceDir", "trace-dir"],
-                describe: "Enable tsserver tracing and write outputs to specified directory",
-                type: "string",
-            },
-            "l": {
-                alias: ["logDir", "log-dir"],
-                describe: "Enable tsserver logging and write log to specified directory",
-                type: "string",
-            },
-            "i": {
-                alias: ["inspectPort", "inspect-port"],
-                describe: "Enable --inspect-brk on the specified port",
-                type: "number",
-            },
-            "u": {
-                alias: ["unattended"],
-                describe: "Stop at the first sign of trouble and use line-oriented output",
-                type: "boolean",
-            },
-            "s": {
-                alias: ["simple"],
-                describe: "Replay only file opening and closing, plus the final request",
-                type: "boolean",
-            },
-            "S": {
-                alias: ["superSimple", "super-simple"],
-                describe: "Replay only the final file opening and the final request",
-                type: "boolean",
-            },
-        })
-        .conflicts("s", "S")
-        .help("h").alias("h", "help")
-        .strict())
-    .argv;
+export interface ReplayOptions {
+    /** Location of directory containing repro project. */
+    project: string;
+    /** Location of file containing server request stubs. */
+    requests: string;
+    /** Location of tsserver.js. */
+    server: string;
+    /** Enable tsserver tracing and write outputs to specified directory. */
+    traceDir?: string;
+    /** Enable tsserver logging and write log to specified directory. */
+    logDir?: string;
+    /** Enable --inspect-brk on the specified port. */
+    inspectPort?: number;
+    /** Stop at the first sign of trouble and use line-oriented output. */
+    unattended?: boolean;
+    /** Replay only file opening and closing, plus the final request. */
+    simple?: boolean;
+    /** Replay only the final file opening and the final request. */
+    superSimple?: boolean;
+}
 
-// @ts-ignore yargs prevents undefined
-const testDir = canonicalizePath(args.project);
-// @ts-ignore yargs prevents undefined
-const requestsPath = canonicalizePath(args.requests);
-// @ts-ignore yargs prevents undefined
-const serverPath = canonicalizePath(args.server);
-
-const traceDir = args.t && canonicalizePath(args.t);
-const logDir = args.l && canonicalizePath(args.l);
-const inspectPort = args.i && +args.i;
-const unattended = !!args.u;
-const simple = !!args.s;
-const superSimple = !!args.S;
-
-/**
- * @param {string} p
- */
-function canonicalizePath(p) {
+export function canonicalizePath(p: string): string {
     // Resolve relative paths now, before we chdir
     // Match the slashes used in server requests
     return path.resolve(p).replace(/\\/g, "/");
 }
 
-// Needed for excludedDirectories
-process.chdir(testDir);
+export async function runReplay(options: ReplayOptions): Promise<void> {
+    const testDir = canonicalizePath(options.project);
+    const requestsPath = canonicalizePath(options.requests);
+    const serverPath = canonicalizePath(options.server);
 
-main().catch(e => {
-    console.log(e);
-    process.exit(1);
-});
+    const traceDir = options.traceDir && canonicalizePath(options.traceDir);
+    const logDir = options.logDir && canonicalizePath(options.logDir);
+    const inspectPort = options.inspectPort && +options.inspectPort;
+    const unattended = !!options.unattended;
+    const simple = !!options.simple;
+    const superSimple = !!options.superSimple;
 
-async function main() {
+    // Needed for excludedDirectories
+    process.chdir(testDir);
+
     const rl = readline.createInterface({
         input: fs.createReadStream(requestsPath),
         crlfDelay: Infinity,
     });
 
     let rootDirPlaceholder = "@PROJECT_ROOT@";
-    let serverArgs = [
+    let serverArgs: string[] = [
         "--disableAutomaticTypingAcquisition",
     ];
 
     let firstLine = true;
     let sawExit = false;
-    let requests = [];
+    let requests: any[] = [];
 
 
     rl.on('line', line => {
@@ -141,7 +108,7 @@ async function main() {
             firstLine = false;
         }
     });
-    await events.once(rl, 'close');
+    await events.EventEmitter.once(rl, 'close');
 
     if (!requests.length) {
         if (!unattended) {
@@ -155,7 +122,7 @@ async function main() {
     }
 
     if (simple) {
-        const newRequests = [];
+        const newRequests: any[] = [];
         let i = 0;
         if (requests[i].command === "configure") {
             newRequests.push(requests[i]);
@@ -182,7 +149,7 @@ async function main() {
         requests = newRequests;
     }
     else if (superSimple) {
-        const newRequests = [];
+        const newRequests: any[] = [];
 
         let h = 0;
         if (requests[h].command === "configure") {
@@ -312,7 +279,7 @@ async function main() {
         }
     }
 
-    async function exitOrKillServer() {
+    async function exitOrKillServer(): Promise<boolean> {
         exitRequested = true; // Suppress "exit" event handler
         return await server.exitOrKill(5000);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "outDir": "dist",
         "rootDir": "src",
         "declaration": true,
+        "sourceMap": true,
     },
     "exclude": ["dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "skipLibCheck": true,
+        "module": "nodenext",
+        "outDir": "dist",
+        "rootDir": "src",
+        "declaration": true,
+    },
+    "exclude": ["dist"]
+}


### PR DESCRIPTION
- Updated this package to use TS instead of JS
- Copied dependency installation code from typescript-error-deltas. Unfortunately I had to also copy a bunch of shared helpers for now.

The idea behind this change is that the ts-error-deltas repro instructions will be updated to just say something like `npx tsreplay install repoDir` instead of listing commands like `npm install ...`. I also intended to update ts-error-deltas to call the install package function from this package, but we'll see.