### PR TITLE
fix: resolve TypeError: process.once is not a function on Linux

### DIFF
--- a/src/stradaReplay.ts
+++ b/src/stradaReplay.ts
@@ -215,7 +215,7 @@ export async function runReplay(options: ReplayOptions): Promise<void> {
     // On Linux, it's idiomatic to shut down your child processes when you receive SIGTERM.
     // This helps us ensure clean teardown during lab runs.
     // NB: As of Node 16, SIGTERM never fires on Windows.
-    process.once("SIGTERM", async () => {
+    global.process.once("SIGTERM", async () => {
         exitRequested = true; // Shouldn't matter, but might as well
         await server.kill();
         // This is a sneaky way to invoke node's default SIGTERM handler


### PR DESCRIPTION
### Description
On Linux environments, running `tsreplay strada-replay` encounters a runtime crash (`TypeError: process.once is not a function`) when setting up the `SIGTERM` event listener. 

This happens because the imported `process` module namespace alias conflicts or loses its native prototype methods depending on the module loading context or child-process scaffolding.

### Changes
- Updated the `SIGTERM` handler registration to explicitly use the global namespace via `global.process.once`.
- Verified that local replays now execute and tear down gracefully without throwing exceptions.

### Verification Results
Before the fix, the CLI failed right after printing the options. After applying the change, the replay completes successfully:
1       status
999999  exit
Shut down